### PR TITLE
Support fargate load balaner checks

### DIFF
--- a/src/config/settings/production.py
+++ b/src/config/settings/production.py
@@ -28,6 +28,14 @@ try:
 except requests.exceptions.RequestException:
     pass
 
+# AWS Fargate containers use a different metadata service
+if not EC2_PRIVATE_IP and env('ECS_CONTAINER_METADATA_URI'):
+    try:
+        CONTAINER_METADATA = requests.get(env('ECS_CONTAINER_METADATA_URI')).json()
+        ALLOWED_HOSTS.extend(CONTAINER_METADATA['Networks'][0]['IPv4Addresses'])
+    except requests.exceptions.RequestException:
+        pass
+
 if EC2_PRIVATE_IP:
     ALLOWED_HOSTS.append(EC2_PRIVATE_IP)
 


### PR DESCRIPTION
Allows for the ALLOWED_HOSTS configuration to support AWS ec2 load balancer healthchecks when running on Fargate ECS containers. 

AWS ec2 load balancers can't be configured to use a host header and instead use the IP address of the endpoint which hosts the application. This adds a call to the container metadata service to get the IP address